### PR TITLE
поправлена сигнатура World.getTilesXY()

### DIFF
--- a/JavaDocs.tex
+++ b/JavaDocs.tex
@@ -4287,7 +4287,7 @@ World}}
 \divideents{getTilesXY}
 \item{\vskip -1.9ex 
 \membername{getTilesXY}
-{\tt public TileType {\bf getTilesXY}(  )
+{\tt public TileType[][] {\bf getTilesXY}(  )
 \label{l303}\label{l304}}%end signature
 \begin{itemize}
 \sld


### PR DESCRIPTION
В доке указано `public TileType getTilesXY( )`,
хотя на самом деле `public TileType[][] getTilesXY( )`
